### PR TITLE
Fix/release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -40,7 +40,7 @@ if [ "$branch" = "master" ]; then
       exit 1
     fi
 
-    commitMessage = "Release $version"
+    commitMessage="Release $version"
 
     npm prune \
     && npm install \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,7 +15,7 @@ switchToBranchRelease () {
 
 if [ -n "$(git status --porcelain)" ]; then
   echo "Git repository is dirty."
-  exit 1
+  #exit 1
 fi
 
 branch=$(git symbolic-ref --short HEAD 2>/dev/null)
@@ -48,9 +48,8 @@ if [ "$branch" = "master" ]; then
     && git clone git@github.com:M6Web/drinkjs.git .tmp \
     && cd .tmp \
     && switchToBranchRelease \
-    && cd .. \
-    && cp -rf lib .tmp/lib \
-    && cp package.json .tmp \
+    && cp -rf ../lib lib \
+    && cp ../package.json . \
     && git add -f lib \
     && git add package.json \
     && git commit -m "$commitMessage" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,7 +15,7 @@ switchToBranchRelease () {
 
 if [ -n "$(git status --porcelain)" ]; then
   echo "Git repository is dirty."
-  #exit 1
+  exit 1
 fi
 
 branch=$(git symbolic-ref --short HEAD 2>/dev/null)


### PR DESCRIPTION
Corrige un problème de syntaxe et le problème de mauvais répertoire de travail pendant le script de release.
(L'execution de 
```sh
git add -f lib \
&& git add package.json \
&& git commit -m "$commitMessage" \
```
se faisait un répertoire trop haut)